### PR TITLE
Grunt/npm compilation, JS update

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,20 +2,20 @@ module.exports = (grunt) ->
   config =
     pkg: grunt.file.readJSON 'package.json'
 
-    coffee:
+    cjsx:
       compile:
         files:
-          'app.js': 'app.coffee'
+          'app-react.js': 'app-react.coffee'
 
     coffeelint:
-      src: ['app.coffee']
+      src: ['app-react.coffee']
       options:
         configFile: '.coffeelintrc'
 
   grunt.initConfig config
 
-  grunt.loadNpmTasks('grunt-contrib-coffee');
-  grunt.loadNpmTasks('grunt-coffeelint');
+  grunt.loadNpmTasks('grunt-coffee-react');
+  grunt.loadNpmTasks('grunt-coffeelint-cjsx');
 
   grunt.registerTask('compile', ['coffee:compile'])
   grunt.registerTask('lint', ['coffeelint'])

--- a/app-react.js
+++ b/app-react.js
@@ -226,6 +226,8 @@
         var cls;
         if (r.workflow_status.name === "Complete" || r.workflow_status.name === "On production") {
           cls = "list-group-item list-group-item-success";
+        } else if (r.workflow_status.name === "Rejected") {
+          cls = "list-group-item list-group-item-danger";
         } else {
           cls = "list-group-item";
         }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "localtunnel": ""
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "dev": "foreman start"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/dbuxton/aha-report.git"
   },
   "devDependencies": {
+    "coffee-react": "",
+    "coffeelint-cjsx": "^2.0.2",
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",
-    "grunt-coffeelint": "0.0.13",
-    "grunt-contrib-coffee": "~0.12.0",
-    "localtunnel": "",
-    "coffee-react": "",
-    "http-server": ""
+    "grunt-coffeelint-cjsx": "^0.1.0",
+    "http-server": "",
+    "localtunnel": ""
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This allows to use npm local dependencies when running the server. foreman should be run through npm using `npm run dev`, which runs foreman while using node modules.

Also updates the Gruntfile so that grunt can compile the Coffeescript/React (just in case) as well as linting.
